### PR TITLE
Inline OpenH264 sample bindings

### DIFF
--- a/openh264/examples/sample_decode.rs
+++ b/openh264/examples/sample_decode.rs
@@ -1,0 +1,110 @@
+//! Minimal example decoding a H.264 file using `openh264-sys2` only.
+//!
+//! The example reads an Annex‑B formatted H.264 bitstream and saves the first
+//! decoded frame as a PNG image.  It implements the few helpers required
+//! directly so the file is self contained.
+
+mod sample_openh264_sys;
+
+use image::RgbImage;
+use sample_openh264_sys::{DecodedYUV, Decoder, Error};
+use std::fs::File;
+use std::io::Read;
+
+
+// How many zeros we must see before a `1` indicates a NAL start.
+const NAL_MIN_0_COUNT: usize = 2;
+
+/// Return the index of the `nth` NAL prefix in `stream`.
+fn nth_nal_index(stream: &[u8], nth: usize) -> Option<usize> {
+    let mut count_0 = 0;
+    let mut n = 0;
+    for (i, byte) in stream.iter().enumerate() {
+        match byte {
+            0 => count_0 += 1,
+            1 if count_0 >= NAL_MIN_0_COUNT => {
+                if n == nth {
+                    return Some(i - NAL_MIN_0_COUNT);
+                }
+                count_0 = 0;
+                n += 1;
+            }
+            _ => count_0 = 0,
+        }
+    }
+    None
+}
+
+/// Split a H.264 Annex‑B stream into NAL units.
+fn nal_units(mut stream: &[u8]) -> impl Iterator<Item = &[u8]> {
+    std::iter::from_fn(move || {
+        let first = nth_nal_index(stream, 0);
+        let next = nth_nal_index(stream, 1);
+        match (first, next) {
+            (Some(f), Some(n)) => {
+                let val = &stream[f..n];
+                stream = &stream[n..];
+                Some(val)
+            }
+            (Some(f), None) => {
+                let val = &stream[f..];
+                stream = &stream[f + NAL_MIN_0_COUNT..];
+                Some(val)
+            }
+            _ => None,
+        }
+    })
+}
+
+
+#[cfg(feature = "source")]
+fn main() -> Result<(), Error> {
+    let mut args = std::env::args();
+    let bin = args.next().unwrap_or_else(|| "sample_decode".into());
+    let input = match args.next() {
+        Some(p) => p,
+        None => {
+            eprintln!("usage: {bin} <h264-file> [output.png]");
+            std::process::exit(1);
+        }
+    };
+    let output = args.next().unwrap_or_else(|| "frame.png".into());
+
+    let mut data = Vec::new();
+    File::open(&input)?.read_to_end(&mut data)?;
+
+    let mut decoder = Decoder::new()?;
+
+    let mut rgb = Vec::new();
+    let mut width = 0usize;
+    let mut height = 0usize;
+
+    for packet in nal_units(&data) {
+        match decoder.decode(packet)? {
+            Some(image) => {
+                let dim = image.dimensions();
+                width = dim.0;
+                height = dim.1;
+                rgb.resize(width * height * 3, 0);
+                image.write_rgb8(&mut rgb);
+                break;
+            }
+            None => continue,
+        }
+    }
+
+    if width == 0 || height == 0 {
+        eprintln!("No frame decoded");
+        return Ok(());
+    }
+
+    let img = RgbImage::from_vec(width as u32, height as u32, rgb)
+        .ok_or_else(|| Error::msg("Failed to create image"))?;
+    img.save(&output)?;
+    println!("Wrote first frame to {output}");
+
+    Ok(())
+}
+
+#[cfg(not(feature = "source"))]
+fn main() {}

--- a/openh264/examples/sample_openh264_sys.rs
+++ b/openh264/examples/sample_openh264_sys.rs
@@ -1,0 +1,303 @@
+//! Minimal OpenH264 decoder wrapper implemented directly in this file.
+
+use std::os::raw::{
+    c_char, c_int, c_long, c_uchar, c_uint, c_void,
+};
+
+// ---------------------------------------------------------------------------
+// FFI definitions extracted from `openh264-sys2`
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct SVideoProperty {
+    pub size: c_uint,
+    pub eVideoBsType: c_int,
+}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct SDecodingParam {
+    pub pFileNameRestructed: *mut c_char,
+    pub uiCpuLoad: c_uint,
+    pub uiTargetDqLayer: c_uchar,
+    pub eEcActiveIdc: c_int,
+    pub bParseOnly: bool,
+    pub sVideoProperty: SVideoProperty,
+}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct SSysMEMBuffer {
+    pub iWidth: c_int,
+    pub iHeight: c_int,
+    pub iFormat: c_int,
+    pub iStride: [c_int; 2],
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union BufferInfoData {
+    pub sSystemBuffer: SSysMEMBuffer,
+}
+
+impl Default for BufferInfoData {
+    fn default() -> Self {
+        unsafe { std::mem::zeroed() }
+    }
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct SBufferInfo {
+    pub iBufferStatus: c_int,
+    pub uiInBsTimeStamp: u64,
+    pub uiOutYuvTimeStamp: u64,
+    pub UsrData: BufferInfoData,
+    pub pDst: [*mut c_uchar; 3],
+}
+
+impl Default for SBufferInfo {
+    fn default() -> Self {
+        unsafe { std::mem::zeroed() }
+    }
+}
+
+pub const DECODER_OPTION_TRACE_LEVEL: c_int = 9;
+pub type DECODER_OPTION = c_int;
+
+pub type ISVCDecoder = *const ISVCDecoderVtbl;
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct ISVCDecoderVtbl {
+    pub Initialize: Option<
+        unsafe extern "C" fn(
+            arg1: *mut ISVCDecoder,
+            pParam: *const SDecodingParam,
+        ) -> c_long,
+    >,
+    pub Uninitialize: Option<unsafe extern "C" fn(arg1: *mut ISVCDecoder) -> c_long>,
+    pub DecodeFrame: Option<
+        unsafe extern "C" fn(
+            arg1: *mut ISVCDecoder,
+            pSrc: *const c_uchar,
+            iSrcLen: c_int,
+            ppDst: *mut *mut c_uchar,
+            pStride: *mut c_int,
+            iWidth: *mut c_int,
+            iHeight: *mut c_int,
+        ) -> c_int,
+    >,
+    pub DecodeFrameNoDelay: Option<
+        unsafe extern "C" fn(
+            arg1: *mut ISVCDecoder,
+            pSrc: *const c_uchar,
+            iSrcLen: c_int,
+            ppDst: *mut *mut c_uchar,
+            pDstInfo: *mut SBufferInfo,
+        ) -> c_int,
+    >,
+    pub DecodeFrame2: Option<
+        unsafe extern "C" fn(
+            arg1: *mut ISVCDecoder,
+            pSrc: *const c_uchar,
+            iSrcLen: c_int,
+            ppDst: *mut *mut c_uchar,
+            pDstInfo: *mut SBufferInfo,
+        ) -> c_int,
+    >,
+    pub FlushFrame: Option<
+        unsafe extern "C" fn(
+            arg1: *mut ISVCDecoder,
+            ppDst: *mut *mut c_uchar,
+            pDstInfo: *mut SBufferInfo,
+        ) -> c_int,
+    >,
+    pub DecodeParser: Option<
+        unsafe extern "C" fn(
+            arg1: *mut ISVCDecoder,
+            pSrc: *const c_uchar,
+            iSrcLen: c_int,
+            pDstInfo: *mut c_void,
+        ) -> c_int,
+    >,
+    pub DecodeFrameEx: Option<
+        unsafe extern "C" fn(
+            arg1: *mut ISVCDecoder,
+            pSrc: *const c_uchar,
+            iSrcLen: c_int,
+            pDst: *mut c_uchar,
+            iDstStride: c_int,
+            iDstLen: *mut c_int,
+            iWidth: *mut c_int,
+            iHeight: *mut c_int,
+            iColorFormat: *mut c_int,
+        ) -> c_int,
+    >,
+    pub SetOption: Option<
+        unsafe extern "C" fn(
+            arg1: *mut ISVCDecoder,
+            eOptionId: DECODER_OPTION,
+            pOption: *mut c_void,
+        ) -> c_long,
+    >,
+    pub GetOption: Option<
+        unsafe extern "C" fn(
+            arg1: *mut ISVCDecoder,
+            eOptionId: DECODER_OPTION,
+            pOption: *mut c_void,
+        ) -> c_long,
+    >,
+}
+
+extern "C" {
+    fn WelsCreateDecoder(ppDecoder: *mut *mut ISVCDecoder) -> c_long;
+    fn WelsDestroyDecoder(pDecoder: *mut ISVCDecoder);
+}
+
+/// Minimal API wrapper that calls the linked OpenH264 C functions.
+pub struct DynamicAPI;
+
+impl DynamicAPI {
+    pub const fn from_source() -> Self {
+        Self
+    }
+
+    pub unsafe fn WelsCreateDecoder(&self, pp: *mut *mut ISVCDecoder) -> c_long {
+        WelsCreateDecoder(pp)
+    }
+
+    pub unsafe fn WelsDestroyDecoder(&self, p: *mut ISVCDecoder) {
+        WelsDestroyDecoder(p)
+    }
+}
+
+
+/// Simple error wrapper used by the examples.
+#[derive(Debug)]
+pub struct Error(Box<dyn std::error::Error>);
+
+impl<E: std::error::Error + 'static> From<E> for Error {
+    fn from(e: E) -> Self {
+        Self(Box::new(e))
+    }
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl std::error::Error for Error {}
+
+impl Error {
+    pub fn msg(msg: &str) -> Self {
+        Self(msg.to_string().into())
+    }
+}
+
+/// Minimal OpenH264 decoder wrapper.
+pub struct Decoder {
+    api: DynamicAPI,
+    inner: *mut *const ISVCDecoderVtbl,
+}
+
+impl Decoder {
+    /// Create a new decoder using the built in OpenH264 source.
+    pub fn new() -> Result<Self, Error> {
+        let api = DynamicAPI::from_source();
+        unsafe {
+            let mut ptr = std::ptr::null::<ISVCDecoderVtbl>() as *mut *const ISVCDecoderVtbl;
+            let rv = api.WelsCreateDecoder(std::ptr::from_mut(&mut ptr));
+            if rv != 0 {
+                return Err(Error::msg("WelsCreateDecoder failed"));
+            }
+            let params = SDecodingParam::default();
+            let init = (*(*ptr)).Initialize.ok_or_else(|| Error::msg("Missing Initialize"))?;
+            if init(ptr as *mut ISVCDecoder, &params as *const _) != 0 {
+                return Err(Error::msg("Initialize failed"));
+            }
+            // Quiet logging.
+            if let Some(set_opt) = (*(*ptr)).SetOption {
+                let mut level: c_int = 0; // WELS_LOG_QUIET
+                set_opt(ptr as *mut ISVCDecoder, DECODER_OPTION_TRACE_LEVEL, &mut level as *mut _ as *mut c_void);
+            }
+            Ok(Self { api, inner: ptr })
+        }
+    }
+
+    /// Decode a single NAL unit and return an image if available.
+    pub fn decode<'a>(&mut self, packet: &[u8]) -> Result<Option<DecodedYUV<'a>>, Error> {
+        unsafe {
+            let mut dst = [std::ptr::null_mut::<u8>(); 3];
+            let mut info = SBufferInfo::default();
+            let decode = (*(*self.inner)).DecodeFrameNoDelay.ok_or_else(|| Error::msg("DecodeFrameNoDelay missing"))?;
+            decode(self.inner as *mut ISVCDecoder, packet.as_ptr(), packet.len() as c_int, dst.as_mut_ptr(), &mut info);
+            if info.iBufferStatus != 0 {
+                let buf: SSysMEMBuffer = info.UsrData.sSystemBuffer;
+                if dst[0].is_null() || dst[1].is_null() || dst[2].is_null() {
+                    return Ok(None);
+                }
+                let y = std::slice::from_raw_parts(dst[0], (buf.iHeight * buf.iStride[0]) as usize);
+                let u = std::slice::from_raw_parts(dst[1], (buf.iHeight * buf.iStride[1] / 2) as usize);
+                let v = std::slice::from_raw_parts(dst[2], (buf.iHeight * buf.iStride[1] / 2) as usize);
+                Ok(Some(DecodedYUV { info: buf, y, u, v }))
+            } else {
+                Ok(None)
+            }
+        }
+    }
+}
+
+impl Drop for Decoder {
+    fn drop(&mut self) {
+        unsafe {
+            if let Some(uninit) = (*(*self.inner)).Uninitialize {
+                uninit(self.inner as *mut ISVCDecoder);
+            }
+            self.api.WelsDestroyDecoder(self.inner);
+        }
+    }
+}
+
+/// Decoded YUV image returned from the decoder.
+pub struct DecodedYUV<'a> {
+    pub info: SSysMEMBuffer,
+    pub y: &'a [u8],
+    pub u: &'a [u8],
+    pub v: &'a [u8],
+}
+
+impl<'a> DecodedYUV<'a> {
+    pub fn dimensions(&self) -> (usize, usize) {
+        (self.info.iWidth as usize, self.info.iHeight as usize)
+    }
+
+    pub fn write_rgb8(&self, target: &mut [u8]) {
+        let (w, h) = self.dimensions();
+        let stride_y = self.info.iStride[0] as usize;
+        let stride_uv = self.info.iStride[1] as usize;
+        for j in 0..h {
+            for i in 0..w {
+                let yv = self.y[j * stride_y + i] as f32;
+                let uv_index = (j / 2) * stride_uv + (i / 2);
+                let u = self.u[uv_index] as f32;
+                let v = self.v[uv_index] as f32;
+
+                let c = (yv - 16.0) * 1.164;
+                let d = u - 128.0;
+                let e = v - 128.0;
+
+                let r = (c + 1.596 * e).clamp(0.0, 255.0);
+                let g = (c - 0.392 * d - 0.813 * e).clamp(0.0, 255.0);
+                let b = (c + 2.017 * d).clamp(0.0, 255.0);
+
+                let idx = (j * w + i) * 3;
+                target[idx] = r as u8;
+                target[idx + 1] = g as u8;
+                target[idx + 2] = b as u8;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- inline required FFI definitions in `sample_openh264_sys.rs`
- example no longer imports the `openh264_sys2` crate

## Testing
- `cargo fmt --all` *(fails: component not installed)*
- `cargo test --quiet` *(fails to download crates due to network)*

------
https://chatgpt.com/codex/tasks/task_e_685c64dd7afc832b807351ca530755bc