### PR TITLE
Implement minimal H264 decoder

### DIFF
--- a/mysimpledecoder/Cargo.toml
+++ b/mysimpledecoder/Cargo.toml
@@ -7,3 +7,7 @@ edition = "2024"
 
 [lints]
 workspace = true
+[build-dependencies]
+cc = { version = "1.0", features = ["parallel"] }
+walkdir = "2.3"
+nasm-rs = "0.3.0"

--- a/mysimpledecoder/build.rs
+++ b/mysimpledecoder/build.rs
@@ -1,0 +1,329 @@
+extern crate core;
+
+use cc::Build;
+use std::path::Path;
+use walkdir::WalkDir;
+
+/// Finds all files with an extension, ignoring some.
+///
+/// TODO: If this gets more complicated, we might want to inline the list of files available in meson.
+fn glob_import<P: AsRef<Path>>(root: P, extenstion: &str, exclude: &str) -> Vec<String> {
+    WalkDir::new(root)
+        .into_iter()
+        .map(|x| x.unwrap())
+        .filter(|x| x.path().to_str().unwrap().ends_with(extenstion))
+        .map(|x| x.path().to_str().unwrap().to_string())
+        .filter(|x| !x.contains(exclude))
+        .collect()
+}
+
+#[derive(Debug, Copy, Clone)]
+enum TargetFamily {
+    Unix,
+    Windows,
+    Wasm,
+}
+#[derive(Debug, Copy, Clone)]
+enum TargetOs {
+    Windows,
+    Macos,
+    Ios,
+    Linux,
+    Android,
+    Freebsd,
+    Dragonfly,
+    Openbsd,
+    Netbsd,
+}
+#[derive(Debug, Copy, Clone)]
+enum TargetArch {
+    X86,
+    X86_64,
+    Arm,
+    Aarch64,
+    Mips,
+    Powerpc,
+    Powerpc64,
+    S390x,
+    Wasm32,
+}
+#[derive(Debug, Copy, Clone)]
+enum TargetEnv {
+    NoEnv,
+    Gnu,
+    Msvc,
+    Musl,
+    Sgx,
+}
+
+#[derive(Debug, Copy, Clone)]
+struct Target {
+    family: TargetFamily,
+    os: TargetOs,
+    arch: TargetArch,
+    env: TargetEnv,
+}
+
+impl Target {
+    fn from_env() -> Self {
+        let family = std::env::var("CARGO_CFG_TARGET_FAMILY").unwrap();
+        let os = std::env::var("CARGO_CFG_TARGET_OS").unwrap();
+        let arch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap();
+        let env = std::env::var("CARGO_CFG_TARGET_ENV").unwrap();
+
+        let family = match family.as_str() {
+            "unix" => TargetFamily::Unix,
+            "windows" => TargetFamily::Windows,
+            "wasm" => TargetFamily::Wasm,
+            _ => panic!("Unknown target family: {family}"),
+        };
+        let os = match os.as_str() {
+            "windows" => TargetOs::Windows,
+            "macos" => TargetOs::Macos,
+            "ios" => TargetOs::Ios,
+            "linux" => TargetOs::Linux,
+            "android" => TargetOs::Android,
+            "freebsd" => TargetOs::Freebsd,
+            "dragonfly" => TargetOs::Dragonfly,
+            "openbsd" => TargetOs::Openbsd,
+            "netbsd" => TargetOs::Netbsd,
+            _ => panic!("Unknown target os: {os}"),
+        };
+        let arch = match arch.as_str() {
+            "x86" => TargetArch::X86,
+            "x86_64" => TargetArch::X86_64,
+            "arm" => TargetArch::Arm,
+            "aarch64" => TargetArch::Aarch64,
+            "mips" => TargetArch::Mips,
+            "powerpc" => TargetArch::Powerpc,
+            "powerpc64" => TargetArch::Powerpc64,
+            "s390x" => TargetArch::S390x,
+            "wasm32" => TargetArch::Wasm32,
+            _ => panic!("Unknown target arch: {arch}"),
+        };
+        let env = match env.as_str() {
+            "" => TargetEnv::NoEnv,
+            "gnu" => TargetEnv::Gnu,
+            "msvc" => TargetEnv::Msvc,
+            "musl" => TargetEnv::Musl,
+            "sgx" => TargetEnv::Sgx,
+            _ => panic!("Unknown target env: {env}"),
+        };
+
+        Self { family, os, arch, env }
+    }
+}
+
+#[derive(Debug)]
+struct NasmConfiguration {
+    /// Extension for assembly files
+    asm_extension: String,
+    /// Directory to add to asm include path
+    include_dir: String,
+    /// Exclude asm files from compilation
+    /// Used to prevent compilation of assembly files included by other assembly files
+    asm_exclude: String,
+    /// A C++ define used to identify the assembly platform
+    cpp_define: String,
+    /// An assembly define used to select sub-platforms
+    asm_platform_define: String,
+    /// Whether to prefix symbols with an underscore
+    prefix_symbols: bool,
+}
+
+impl NasmConfiguration {
+    fn find(target: Target) -> Option<Self> {
+        use TargetArch::*;
+        use TargetFamily::*;
+        // use TargetEnv::*;
+        use TargetOs::*;
+
+        match target.arch {
+            // for now, we only support building asm with nasm
+            // and nasm only supports x86 and x86_64
+            // sooo, even though we have some logic for other arches coded, we don't actually support them
+            X86_64 | X86 => {}
+            _ => return None,
+        }
+
+        // this function basically repeats what is done across several included makefiles in the `build` directory of the upstream
+
+        let asm_extension = match target.arch {
+            X86_64 | X86 => ".asm",
+            Aarch64 | Arm => ".S",
+            _ => return None,
+        };
+
+        let asm_dir = match target.arch {
+            X86_64 | X86 => "x86",
+            Aarch64 => "arm64",
+            Arm => "arm",
+            _ => return None,
+        };
+
+        let asm_exclude = match target.arch {
+            X86_64 | X86 => "asm_inc.asm",
+            Aarch64 => "arm_arch64_common_macro.S",
+            Arm => "arm_arch_common_macro.S",
+            _ => return None,
+        };
+
+        // CPP defines to inform which assembly symbols to use.
+        let cpp_define = match target.arch {
+            X86_64 | X86 => "X86_ASM",
+            Aarch64 => "HAVE_NEON_AARCH64",
+            Arm => "HAVE_NEON",
+            _ => return None,
+        };
+
+        // A special define needed for some platforms.
+        let asm_platform_define = match target.arch {
+            X86_64 => match target.family {
+                Unix => "UNIX64",
+                TargetFamily::Windows => "WIN64",
+                _ => return None,
+            },
+            X86 => "X86_32",
+            Aarch64 => "HAVE_NEON_AARCH64",
+            Arm => "HAVE_NEON",
+            _ => return None,
+        };
+
+        // Prefix symbols exported from assembly with an underscore on x86/x86_64 macOS and x86 Windows.
+        let prefix_underscores = matches!(
+            target,
+            Target {
+                os: Macos,
+                arch: X86_64 | X86,
+                ..
+            } | Target {
+                os: TargetOs::Windows,
+                arch: X86,
+                ..
+            }
+        );
+
+        Some(Self {
+            asm_extension: asm_extension.to_string(),
+            include_dir: asm_dir.to_string(),
+            asm_exclude: asm_exclude.to_string(),
+            cpp_define: cpp_define.to_string(),
+            asm_platform_define: asm_platform_define.to_string(),
+            prefix_symbols: prefix_underscores,
+        })
+    }
+}
+
+#[allow(unused)]
+fn try_compile_nasm(cc_build_command: &mut Build, root: &str) {
+    if std::env::var("OPENH264_NO_ASM").is_ok() {
+        println!("NASM compilation disabled by environment variable.");
+        return;
+    }
+
+    let target = Target::from_env();
+
+    let Some(config) = NasmConfiguration::find(target) else {
+        println!("No NASM configuration found for target, not using any assembly.\nTarget: {target:?}");
+        return;
+    };
+
+    // Try to compile NASM targets
+    let mut nasm_build = nasm_rs::Build::new();
+    let mut nasm_build = nasm_build.include(format!("../openh264-sys2/upstream/codec/common/{}/", config.include_dir));
+    nasm_build = nasm_build.define(&config.asm_platform_define, None);
+    if config.prefix_symbols {
+        nasm_build = nasm_build.define("PREFIX", None);
+    }
+
+    // Run `nasm` and store result.
+    // TODO: is it a good idea to "silently" disable assembly if this fails?
+    let Ok(object_files) = nasm_build
+        .files(glob_import(root, &config.asm_extension, &config.asm_exclude))
+        .compile_objects()
+    else {
+        println!("Failed to compile NASM files, not using any assembly.");
+        return;
+    };
+
+    // This here only _EXTENDS_ the build command we got passed, it doesn't
+    // _RUN_ any build command on its own (we still invoked `nasm` above
+    // though).
+    cc_build_command.define(&config.cpp_define, None);
+
+    for object in &object_files {
+        cc_build_command.object(object);
+    }
+}
+
+/// Builds an OpenH264 sub-library and adds it to the project.
+fn compile_and_add_openh264_static_lib(name: &str, root: &str, includes: &[&str]) {
+    let mut cc_build = cc::Build::new();
+
+    try_compile_nasm(&mut cc_build, root);
+
+    cc_build
+        .include("../openh264-sys2/upstream/codec/api/wels/")
+        .include("../openh264-sys2/upstream/codec/common/inc/")
+        .cpp(true)
+        .warnings(false)
+        .files(glob_import(root, ".cpp", "DllEntry.cpp")) // Otherwise fails when compiling on Linux
+        .pic(true)
+        // Upstream sets these two and if we don't we get segmentation faults on Linux and MacOS ... Happy times.
+        .flag_if_supported("-fno-strict-aliasing")
+        .flag_if_supported("-fembed-bitcode")
+        .flag_if_supported("-fno-common")
+        .flag_if_supported("-undefined dynamic_lookup");
+
+    // disable stack protectors on mingw:
+    // (seems to be the way to go https://github.com/rdp/ffmpeg-windows-build-helpers/issues/380)
+
+    if let Target {
+        os: TargetOs::Windows,
+        env: TargetEnv::Gnu,
+        ..
+    } = Target::from_env()
+    {
+    } else {
+        cc_build.flag_if_supported("-fstack-protector-all");
+    }
+
+    for include in includes {
+        cc_build.include(include);
+    }
+
+    cc_build.compile(format!("openh264_{name}").as_str());
+
+    println!("cargo:rustc-link-lib=static=openh264_{name}");
+}
+
+fn main() {
+    compile_and_add_openh264_static_lib("common", "../openh264-sys2/upstream/codec/common", &[]);
+
+    compile_and_add_openh264_static_lib(
+        "processing",
+        "../openh264-sys2/upstream/codec/processing",
+        &[
+            "../openh264-sys2/upstream/codec/processing/src/common/",
+            "../openh264-sys2/upstream/codec/processing/interface/",
+        ],
+    );
+
+    // #[cfg(feature = "decoder")]
+    compile_and_add_openh264_static_lib(
+        "decoder",
+        "../openh264-sys2/upstream/codec/decoder",
+        &["../openh264-sys2/upstream/codec/decoder/core/inc/", "../openh264-sys2/upstream/codec/decoder/plus/inc/"],
+    );
+
+    // #[cfg(feature = "encoder")]
+    compile_and_add_openh264_static_lib(
+        "encoder",
+        "../openh264-sys2/upstream/codec/encoder",
+        &[
+            "../openh264-sys2/upstream/codec/encoder/core/inc/",
+            "../openh264-sys2/upstream/codec/encoder/plus/inc/",
+            "../openh264-sys2/upstream/codec/processing/interface/",
+        ],
+    );
+}

--- a/mysimpledecoder/src/decoder.rs
+++ b/mysimpledecoder/src/decoder.rs
@@ -1,0 +1,303 @@
+//! Minimal OpenH264 decoder wrapper implemented directly in this file.
+
+use std::os::raw::{
+    c_char, c_int, c_long, c_uchar, c_uint, c_void,
+};
+
+// ---------------------------------------------------------------------------
+// FFI definitions extracted from `openh264-sys2`
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct SVideoProperty {
+    pub size: c_uint,
+    pub eVideoBsType: c_int,
+}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct SDecodingParam {
+    pub pFileNameRestructed: *mut c_char,
+    pub uiCpuLoad: c_uint,
+    pub uiTargetDqLayer: c_uchar,
+    pub eEcActiveIdc: c_int,
+    pub bParseOnly: bool,
+    pub sVideoProperty: SVideoProperty,
+}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct SSysMEMBuffer {
+    pub iWidth: c_int,
+    pub iHeight: c_int,
+    pub iFormat: c_int,
+    pub iStride: [c_int; 2],
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union BufferInfoData {
+    pub sSystemBuffer: SSysMEMBuffer,
+}
+
+impl Default for BufferInfoData {
+    fn default() -> Self {
+        unsafe { std::mem::zeroed() }
+    }
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct SBufferInfo {
+    pub iBufferStatus: c_int,
+    pub uiInBsTimeStamp: u64,
+    pub uiOutYuvTimeStamp: u64,
+    pub UsrData: BufferInfoData,
+    pub pDst: [*mut c_uchar; 3],
+}
+
+impl Default for SBufferInfo {
+    fn default() -> Self {
+        unsafe { std::mem::zeroed() }
+    }
+}
+
+pub const DECODER_OPTION_TRACE_LEVEL: c_int = 9;
+pub type DECODER_OPTION = c_int;
+
+pub type ISVCDecoder = *const ISVCDecoderVtbl;
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct ISVCDecoderVtbl {
+    pub Initialize: Option<
+        unsafe extern "C" fn(
+            arg1: *mut ISVCDecoder,
+            pParam: *const SDecodingParam,
+        ) -> c_long,
+    >,
+    pub Uninitialize: Option<unsafe extern "C" fn(arg1: *mut ISVCDecoder) -> c_long>,
+    pub DecodeFrame: Option<
+        unsafe extern "C" fn(
+            arg1: *mut ISVCDecoder,
+            pSrc: *const c_uchar,
+            iSrcLen: c_int,
+            ppDst: *mut *mut c_uchar,
+            pStride: *mut c_int,
+            iWidth: *mut c_int,
+            iHeight: *mut c_int,
+        ) -> c_int,
+    >,
+    pub DecodeFrameNoDelay: Option<
+        unsafe extern "C" fn(
+            arg1: *mut ISVCDecoder,
+            pSrc: *const c_uchar,
+            iSrcLen: c_int,
+            ppDst: *mut *mut c_uchar,
+            pDstInfo: *mut SBufferInfo,
+        ) -> c_int,
+    >,
+    pub DecodeFrame2: Option<
+        unsafe extern "C" fn(
+            arg1: *mut ISVCDecoder,
+            pSrc: *const c_uchar,
+            iSrcLen: c_int,
+            ppDst: *mut *mut c_uchar,
+            pDstInfo: *mut SBufferInfo,
+        ) -> c_int,
+    >,
+    pub FlushFrame: Option<
+        unsafe extern "C" fn(
+            arg1: *mut ISVCDecoder,
+            ppDst: *mut *mut c_uchar,
+            pDstInfo: *mut SBufferInfo,
+        ) -> c_int,
+    >,
+    pub DecodeParser: Option<
+        unsafe extern "C" fn(
+            arg1: *mut ISVCDecoder,
+            pSrc: *const c_uchar,
+            iSrcLen: c_int,
+            pDstInfo: *mut c_void,
+        ) -> c_int,
+    >,
+    pub DecodeFrameEx: Option<
+        unsafe extern "C" fn(
+            arg1: *mut ISVCDecoder,
+            pSrc: *const c_uchar,
+            iSrcLen: c_int,
+            pDst: *mut c_uchar,
+            iDstStride: c_int,
+            iDstLen: *mut c_int,
+            iWidth: *mut c_int,
+            iHeight: *mut c_int,
+            iColorFormat: *mut c_int,
+        ) -> c_int,
+    >,
+    pub SetOption: Option<
+        unsafe extern "C" fn(
+            arg1: *mut ISVCDecoder,
+            eOptionId: DECODER_OPTION,
+            pOption: *mut c_void,
+        ) -> c_long,
+    >,
+    pub GetOption: Option<
+        unsafe extern "C" fn(
+            arg1: *mut ISVCDecoder,
+            eOptionId: DECODER_OPTION,
+            pOption: *mut c_void,
+        ) -> c_long,
+    >,
+}
+
+extern "C" {
+    fn WelsCreateDecoder(ppDecoder: *mut *mut ISVCDecoder) -> c_long;
+    fn WelsDestroyDecoder(pDecoder: *mut ISVCDecoder);
+}
+
+/// Minimal API wrapper that calls the linked OpenH264 C functions.
+pub struct DynamicAPI;
+
+impl DynamicAPI {
+    pub const fn from_source() -> Self {
+        Self
+    }
+
+    pub unsafe fn WelsCreateDecoder(&self, pp: *mut *mut ISVCDecoder) -> c_long {
+        WelsCreateDecoder(pp)
+    }
+
+    pub unsafe fn WelsDestroyDecoder(&self, p: *mut ISVCDecoder) {
+        WelsDestroyDecoder(p)
+    }
+}
+
+
+/// Simple error wrapper used by the examples.
+#[derive(Debug)]
+pub struct Error(Box<dyn std::error::Error>);
+
+impl<E: std::error::Error + 'static> From<E> for Error {
+    fn from(e: E) -> Self {
+        Self(Box::new(e))
+    }
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl std::error::Error for Error {}
+
+impl Error {
+    pub fn msg(msg: &str) -> Self {
+        Self(msg.to_string().into())
+    }
+}
+
+/// Minimal OpenH264 decoder wrapper.
+pub struct Decoder {
+    api: DynamicAPI,
+    inner: *mut *const ISVCDecoderVtbl,
+}
+
+impl Decoder {
+    /// Create a new decoder using the built in OpenH264 source.
+    pub fn new() -> Result<Self, Error> {
+        let api = DynamicAPI::from_source();
+        unsafe {
+            let mut ptr = std::ptr::null::<ISVCDecoderVtbl>() as *mut *const ISVCDecoderVtbl;
+            let rv = api.WelsCreateDecoder(std::ptr::from_mut(&mut ptr));
+            if rv != 0 {
+                return Err(Error::msg("WelsCreateDecoder failed"));
+            }
+            let params = SDecodingParam::default();
+            let init = (*(*ptr)).Initialize.ok_or_else(|| Error::msg("Missing Initialize"))?;
+            if init(ptr as *mut ISVCDecoder, &params as *const _) != 0 {
+                return Err(Error::msg("Initialize failed"));
+            }
+            // Quiet logging.
+            if let Some(set_opt) = (*(*ptr)).SetOption {
+                let mut level: c_int = 0; // WELS_LOG_QUIET
+                set_opt(ptr as *mut ISVCDecoder, DECODER_OPTION_TRACE_LEVEL, &mut level as *mut _ as *mut c_void);
+            }
+            Ok(Self { api, inner: ptr })
+        }
+    }
+
+    /// Decode a single NAL unit and return an image if available.
+    pub fn decode<'a>(&mut self, packet: &[u8]) -> Result<Option<DecodedYUV<'a>>, Error> {
+        unsafe {
+            let mut dst = [std::ptr::null_mut::<u8>(); 3];
+            let mut info = SBufferInfo::default();
+            let decode = (*(*self.inner)).DecodeFrameNoDelay.ok_or_else(|| Error::msg("DecodeFrameNoDelay missing"))?;
+            decode(self.inner as *mut ISVCDecoder, packet.as_ptr(), packet.len() as c_int, dst.as_mut_ptr(), &mut info);
+            if info.iBufferStatus != 0 {
+                let buf: SSysMEMBuffer = info.UsrData.sSystemBuffer;
+                if dst[0].is_null() || dst[1].is_null() || dst[2].is_null() {
+                    return Ok(None);
+                }
+                let y = std::slice::from_raw_parts(dst[0], (buf.iHeight * buf.iStride[0]) as usize);
+                let u = std::slice::from_raw_parts(dst[1], (buf.iHeight * buf.iStride[1] / 2) as usize);
+                let v = std::slice::from_raw_parts(dst[2], (buf.iHeight * buf.iStride[1] / 2) as usize);
+                Ok(Some(DecodedYUV { info: buf, y, u, v }))
+            } else {
+                Ok(None)
+            }
+        }
+    }
+}
+
+impl Drop for Decoder {
+    fn drop(&mut self) {
+        unsafe {
+            if let Some(uninit) = (*(*self.inner)).Uninitialize {
+                uninit(self.inner as *mut ISVCDecoder);
+            }
+            self.api.WelsDestroyDecoder(self.inner);
+        }
+    }
+}
+
+/// Decoded YUV image returned from the decoder.
+pub struct DecodedYUV<'a> {
+    pub info: SSysMEMBuffer,
+    pub y: &'a [u8],
+    pub u: &'a [u8],
+    pub v: &'a [u8],
+}
+
+impl<'a> DecodedYUV<'a> {
+    pub fn dimensions(&self) -> (usize, usize) {
+        (self.info.iWidth as usize, self.info.iHeight as usize)
+    }
+
+    pub fn write_rgb8(&self, target: &mut [u8]) {
+        let (w, h) = self.dimensions();
+        let stride_y = self.info.iStride[0] as usize;
+        let stride_uv = self.info.iStride[1] as usize;
+        for j in 0..h {
+            for i in 0..w {
+                let yv = self.y[j * stride_y + i] as f32;
+                let uv_index = (j / 2) * stride_uv + (i / 2);
+                let u = self.u[uv_index] as f32;
+                let v = self.v[uv_index] as f32;
+
+                let c = (yv - 16.0) * 1.164;
+                let d = u - 128.0;
+                let e = v - 128.0;
+
+                let r = (c + 1.596 * e).clamp(0.0, 255.0);
+                let g = (c - 0.392 * d - 0.813 * e).clamp(0.0, 255.0);
+                let b = (c + 2.017 * d).clamp(0.0, 255.0);
+
+                let idx = (j * w + i) * 3;
+                target[idx] = r as u8;
+                target[idx + 1] = g as u8;
+                target[idx + 2] = b as u8;
+            }
+        }
+    }
+}

--- a/mysimpledecoder/src/main.rs
+++ b/mysimpledecoder/src/main.rs
@@ -1,3 +1,99 @@
-fn main() {
-    println!("Hello, world!");
+mod decoder;
+
+use decoder::{Decoder, Error};
+use std::fs::File;
+use std::io::{Read, Write};
+
+const NAL_MIN_0_COUNT: usize = 2;
+
+fn nth_nal_index(stream: &[u8], nth: usize) -> Option<usize> {
+    let mut count_0 = 0;
+    let mut n = 0;
+    for (i, byte) in stream.iter().enumerate() {
+        match byte {
+            0 => count_0 += 1,
+            1 if count_0 >= NAL_MIN_0_COUNT => {
+                if n == nth {
+                    return Some(i - NAL_MIN_0_COUNT);
+                }
+                count_0 = 0;
+                n += 1;
+            }
+            _ => count_0 = 0,
+        }
+    }
+    None
+}
+
+fn nal_units(mut stream: &[u8]) -> impl Iterator<Item = &[u8]> {
+    std::iter::from_fn(move || {
+        let first = nth_nal_index(stream, 0);
+        let next = nth_nal_index(stream, 1);
+        match (first, next) {
+            (Some(f), Some(n)) => {
+                let val = &stream[f..n];
+                stream = &stream[n..];
+                Some(val)
+            }
+            (Some(f), None) => {
+                let val = &stream[f..];
+                stream = &stream[f + NAL_MIN_0_COUNT..];
+                Some(val)
+            }
+            _ => None,
+        }
+    })
+}
+
+fn write_ppm(path: &str, rgb: &[u8], width: usize, height: usize) -> Result<(), std::io::Error> {
+    let mut file = File::create(path)?;
+    writeln!(file, "P6\n{} {}\n255", width, height)?;
+    file.write_all(rgb)?;
+    Ok(())
+}
+
+fn main() -> Result<(), Error> {
+    let mut args = std::env::args();
+    let bin = args.next().unwrap_or_else(|| "mysimpledecoder".into());
+    let input = match args.next() {
+        Some(p) => p,
+        None => {
+            eprintln!("usage: {bin} <h264-file> [output.ppm]");
+            std::process::exit(1);
+        }
+    };
+    let output = args.next().unwrap_or_else(|| "frame.ppm".into());
+
+    let mut data = Vec::new();
+    File::open(&input)?.read_to_end(&mut data)?;
+
+    let mut decoder = Decoder::new()?;
+
+    let mut rgb = Vec::new();
+    let mut width = 0usize;
+    let mut height = 0usize;
+
+    for packet in nal_units(&data) {
+        match decoder.decode(packet)? {
+            Some(image) => {
+                let dim = image.dimensions();
+                width = dim.0;
+                height = dim.1;
+                rgb.resize(width * height * 3, 0);
+                image.write_rgb8(&mut rgb);
+                break;
+            }
+            None => continue,
+        }
+    }
+
+    if width == 0 || height == 0 {
+        eprintln!("No frame decoded");
+        return Ok(());
+    }
+
+    write_ppm(&output, &rgb, width, height)?;
+    println!("Wrote first frame to {output}");
+
+    Ok(())
 }


### PR DESCRIPTION
## Summary
- add custom build script to compile OpenH264
- implement a minimal decoder using OpenH264 FFI
- write a basic `main` to decode the first frame and save as a PPM image

## Testing
- `cargo build -p mysimpledecoder --release` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_685db43b3524832b9b92aebd46d726ab